### PR TITLE
Fix bad debug condition causing client to override server time

### DIFF
--- a/src/main/java/com/unixkitty/timecontrol/handler/ClientTimeHandler.java
+++ b/src/main/java/com/unixkitty/timecontrol/handler/ClientTimeHandler.java
@@ -23,11 +23,14 @@ public class ClientTimeHandler implements ITimeHandler
         //In system time synchronization mode we simply depend on server time packets
         if (!Config.sync_to_system_time.get())
         {
-            debugLogDelay++;
+            debugLogDelay = (debugLogDelay + 1) % 20;
 
-            if (multiplier == 0 && debugLogDelay == 20)
+            if (multiplier == 0)
             {
-                log.info("Waiting for server time packet...");
+                if (debugLogDelay == 0 && Config.debugMode.get())
+                {
+                    log.info("Waiting for server time packet...");
+                }
 
                 return;
             }
@@ -39,7 +42,7 @@ public class ClientTimeHandler implements ITimeHandler
                 Numbers.setWorldtime(world, customtime, multiplier);
             }
 
-            if (debugLogDelay == 20 && Config.debugMode.get())
+            if (debugLogDelay == 0 && Config.debugMode.get())
             {
                 long worldtime = world.getDayTime();
 
@@ -49,11 +52,6 @@ public class ClientTimeHandler implements ITimeHandler
                         world.getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE),
                         world.getGameRules().getBoolean(TimeEvents.DO_DAYLIGHT_CYCLE_TC)
                 ));
-            }
-
-            if (debugLogDelay >= 20)
-            {
-                debugLogDelay = 0;
             }
         }
     }


### PR DESCRIPTION
`ClientTimeHandler` had a bad if-return check causing the client to override server time, which would visually manifest as flickering between two times as the client and server fought for control. This would not happen if the client had the system time configuration option set, but it's not uncommon for client and server configs to differ.

This PR fixes the issue in the 1.16 branch. It looks like the fix additionally needs to be backported to 1.15 and 1.12; the 1.15 backport should be a trivial cherry-pick, wheras 1.12 will need manual intervention.

The bulk of the fix is disentangling the if-condition; the rest of the changes are noise from fixing the debug log delay to work as intended.