### PR TITLE
Add option to offset hour for system sync

### DIFF
--- a/src/main/java/com/unixkitty/timecontrol/TimeControlCommand.java
+++ b/src/main/java/com/unixkitty/timecontrol/TimeControlCommand.java
@@ -27,6 +27,7 @@ public class TimeControlCommand
         registerCommand(Config.night_length_minutes, command);
         registerCommand(Config.sync_to_system_time, command);
         registerCommand(Config.sync_to_system_time_rate, command);
+        registerCommand(Config.sync_to_system_time_offset, command);
 
         dispatcher.register(command);
     }

--- a/src/main/java/com/unixkitty/timecontrol/config/Config.java
+++ b/src/main/java/com/unixkitty/timecontrol/config/Config.java
@@ -14,6 +14,7 @@ public class Config
 
     public static JsonConfig.BooleanValue sync_to_system_time;
     public static JsonConfig.IntValue sync_to_system_time_rate;
+    public static JsonConfig.IntValue sync_to_system_time_offset;
 
     public static JsonConfig.IntValue day_length_minutes;
     public static JsonConfig.IntValue night_length_minutes;
@@ -27,6 +28,7 @@ public class Config
 
             sync_to_system_time = CONFIG.defineValue("sync_to_system_time", false);
             sync_to_system_time_rate = CONFIG.defineInRange("sync_to_system_time_rate", 20, 1, 864000);
+            sync_to_system_time_offset= CONFIG.defineInRange("sync_to_system_time_offset", 0, -23, 23);
 
             day_length_minutes = CONFIG.defineInRange("day_length_minutes", 10, 1, 178956);
             night_length_minutes = CONFIG.defineInRange("night_length_minutes", 10, 1, 178956);

--- a/src/main/java/com/unixkitty/timecontrol/handler/ClientTimeHandler.java
+++ b/src/main/java/com/unixkitty/timecontrol/handler/ClientTimeHandler.java
@@ -86,6 +86,7 @@ public final class ClientTimeHandler extends TimeHandler
             Config.day_length_minutes.set(message.day_length_minutes);
             Config.night_length_minutes.set(message.night_length_minutes);
             Config.sync_to_system_time_rate.set(message.sync_to_system_time_rate);
+            Config.sync_to_system_time_offset.set(message.sync_to_system_time_offset);
             Config.sync_to_system_time.set(message.sync_to_system_time);
 
             Config.save();

--- a/src/main/java/com/unixkitty/timecontrol/handler/ServerTimeHandler.java
+++ b/src/main/java/com/unixkitty/timecontrol/handler/ServerTimeHandler.java
@@ -165,7 +165,7 @@ public final class ServerTimeHandler extends TimeHandler
         if (minute != this.lastMinute)
         {
             long worldTime = level.getDayTime();
-            int hour = now.getHour();
+            int hour = now.getHour() + Config.sync_to_system_time_offset.get();
             int day = LocalDate.now().getDayOfYear();
             long time = Numbers.getSystemtimeTicks(hour, minute, day);
 

--- a/src/main/java/com/unixkitty/timecontrol/network/packet/ConfigS2CPacket.java
+++ b/src/main/java/com/unixkitty/timecontrol/network/packet/ConfigS2CPacket.java
@@ -8,6 +8,7 @@ public class ConfigS2CPacket extends BasePacket
     public final int day_length_minutes;
     public final int night_length_minutes;
     public final int sync_to_system_time_rate;
+    public final int sync_to_system_time_offset;
     public final boolean sync_to_system_time;
 
     public ConfigS2CPacket()
@@ -15,6 +16,7 @@ public class ConfigS2CPacket extends BasePacket
         this.day_length_minutes = Config.day_length_minutes.get();
         this.night_length_minutes = Config.night_length_minutes.get();
         this.sync_to_system_time_rate = Config.sync_to_system_time_rate.get();
+        this.sync_to_system_time_offset = Config.sync_to_system_time_offset.get();
         this.sync_to_system_time = Config.sync_to_system_time.get();
     }
 
@@ -23,6 +25,7 @@ public class ConfigS2CPacket extends BasePacket
         this.day_length_minutes = buffer.readInt();
         this.night_length_minutes = buffer.readInt();
         this.sync_to_system_time_rate = buffer.readInt();
+        this.sync_to_system_time_offset = buffer.readInt();
         this.sync_to_system_time = buffer.readBoolean();
     }
 
@@ -32,6 +35,7 @@ public class ConfigS2CPacket extends BasePacket
         buffer.writeInt(this.day_length_minutes);
         buffer.writeInt(this.night_length_minutes);
         buffer.writeInt(this.sync_to_system_time_rate);
+        buffer.writeInt(this.sync_to_system_time_offset);
         buffer.writeBoolean(this.sync_to_system_time);
 
         return buffer;


### PR DESCRIPTION
I'd like to change this to a `double` at some point for less common use cases (some time zones are off by increments less than an hour), but it seemed like it would require more intrusive changes I was comfortable with.

I can send over a PR for the 1.20 forge branch as well if you're okay with how I did this. And also, I didn't want to make changes to the readme to include the new option in case you wanted to word it yourself/until after the concept is approved.