### PR TITLE
Refine system time sync mechanism

### DIFF
--- a/src/main/java/com/unixkitty/timecontrol/Numbers.java
+++ b/src/main/java/com/unixkitty/timecontrol/Numbers.java
@@ -26,6 +26,7 @@ public class Numbers
     private static final int real_life_minute_is_ticks = real_life_second_is_ticks * 60;
     private static final double vanilla_multiplier = HALF_DAY_TICKS / (double) real_life_second_is_ticks;
     private static final double real_life_minute_multiplier = real_life_minute_is_ticks / 72.0D; //Minecraft "time" is 72 times faster than IRL: 1440 IRL minutes / 20 (length of a Mineraft day in minutes)
+    private static final double real_life_second_multiplier = real_life_minute_is_ticks / 72.0D / 60.0D;
 
     static
     {
@@ -103,11 +104,12 @@ public class Numbers
         return l >= 0 && l < HALF_DAY_TICKS;
     }
 
-    public static long getSystemtimeTicks(int hour, int minute, int day)
+    public static long getSystemtimeTicks(int hour, int minute, int second, int day)
     {
-        hour = (hour - real_life_hour_offset + hours_per_day) % hours_per_day * ticks_per_hour;
-        minute = (int) Math.round(minute * real_life_minute_multiplier % ticks_per_hour);
+        double hourTicks = (hour - real_life_hour_offset + hours_per_day) % hours_per_day * ticks_per_hour;
+        double minuteTicks = minute * real_life_minute_multiplier;
+        double secondTicks = second * real_life_second_multiplier;
 
-        return (hour + minute) + (day * DAY_TICKS);
+        return (int)Math.round(hourTicks + minuteTicks + secondTicks) + (day * DAY_TICKS);
     }
 }


### PR DESCRIPTION
### Add ability to disable system time sync with the gamerule (fix #27)

System time sync can be disabled using the gamerule `doDaylightCycle_tc` on a per-world basis without needing to reload the config file. This is especially useful in modpacks where [server config is made global and no longer per-world](https://modrinth.com/mod/global-server-config).

Setting `doDaylightCycle_tc` to `false` will also allow `/time set` and `/time add` to be used.

### Take seconds into account when synchronizing time

The original behavior can only synchronize in precision up to minute-level. This is problematic since:

- One "Minecraft minute" is approximately 16.67 ticks. The precision is simply not absolutely enough.
- This makes it de-facto pointless to set `sync_to_system_time_rate` below one minute.
- Some mods such as supplementaries provide in-game clocks that can display in-game time in 24-hour format. If the precision of the synchronization is only minute-level, the reading of the clock can be one-minute off due to rounding errors (and possibly two-minutes off if `sync_to_system_time_rate` is a little long).

### Modify initial value of `lastMinute` to -1

Obviously, with the original implementation, if the world is loaded at 14:00, the time synchronization will not happen until 14:01. Setting the initial value to an impossible value can fix this.